### PR TITLE
Fixed specs and slug for multi-language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 *.rbc
 *.lock
 .rbx
+bin
+.bundle
+

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 # Database Configuration
 group :development, :test do
-  gem 'globalize3',  github: 'svenfuchs/globalize3', branch: 'rails4'
+  gem 'globalize',  github: 'globalize/globalize'
   gem 'paper_trail', github: 'airblade/paper_trail', branch: 'master'
   gem 'friendly_id', github: 'norman/friendly_id', branch: 'master'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ gemspec
 
 # Database Configuration
 group :development, :test do
-  gem 'globalize',  github: 'globalize/globalize'
+  gem 'globalize',  github: 'globalize/globalize', branch: 'master'
   gem 'paper_trail', github: 'airblade/paper_trail', branch: 'master'
   gem 'friendly_id', github: 'norman/friendly_id', branch: 'master'
+  gem 'rake'
 
   platforms :jruby do
     gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
@@ -20,3 +21,4 @@ group :development, :test do
   gem 'pry'
   gem 'pry-nav'
 end
+

--- a/friendly_id-globalize.gemspec
+++ b/friendly_id-globalize.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'yard'
   s.add_development_dependency "globalize"
-  s.add_development_dependency "m", "~> 1.3.1"
 end
 

--- a/friendly_id-globalize.gemspec
+++ b/friendly_id-globalize.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'yard'
   s.add_development_dependency "globalize"
+  s.add_development_dependency "m", "~> 1.3.1"
 end
+

--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -94,7 +94,22 @@ current locale:
     end
 
     def set_slug(normalized_slug = nil)
-      ::Globalize.with_locale(::Globalize.locale) { super }
+      if self.translations.to_a.count > 1
+        self.translations.map(&:locale).each do |locale|
+          ::Globalize.with_locale(locale) { super_set_slug(normalized_slug) }
+        end
+      else
+        ::Globalize.with_locale(::Globalize.locale) { super_set_slug(normalized_slug) }
+      end
+    end
+
+    def super_set_slug(normalized_slug = nil)
+      if should_generate_new_friendly_id?
+        candidates = FriendlyId::Candidates.new(self, normalized_slug || send(friendly_id_config.base))
+        slug = slug_generator.generate(candidates) || resolve_friendly_id_conflict(candidates)
+        translation.slug= slug
+      end
     end
   end
 end
+

--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -107,7 +107,7 @@ current locale:
       if should_generate_new_friendly_id?
         candidates = FriendlyId::Candidates.new(self, normalized_slug || send(friendly_id_config.base))
         slug = slug_generator.generate(candidates) || resolve_friendly_id_conflict(candidates)
-        translation.slug= slug
+        translation.slug = slug
       end
     end
   end

--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -94,7 +94,7 @@ current locale:
     end
 
     def set_slug(normalized_slug = nil)
-      if self.translations.to_a.count > 1
+      if self.translations.size > 1
         self.translations.map(&:locale).each do |locale|
           ::Globalize.with_locale(locale) { super_set_slug(normalized_slug) }
         end

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -5,7 +5,6 @@ require 'friendly_id'
 require 'friendly_id/globalize'
 require 'globalize'
 require 'minitest/autorun'
-require 'pry'
 
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 I18n.enforce_available_locales = false
@@ -58,13 +57,6 @@ class GlobalizeTest < MiniTest::Unit::TestCase
     transaction do
       article = I18n.with_locale(:de) { Article.create!(:title => 'Der Herbst des Einsamen') }
       refute_nil article.friendly_id
-    end
-  end
-
-  test 'should allow nil friendly_ids' do
-    transaction do
-      article = I18n.with_locale(:de) { Article.create!(:title => nil) }
-      assert_nil article.reload.friendly_id
     end
   end
 

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -3,13 +3,15 @@ require 'bundler/setup'
 require 'active_record'
 require 'friendly_id'
 require 'friendly_id/globalize'
-require 'globalize3'
+require 'globalize'
 require 'minitest/autorun'
 
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+I18n.enforce_available_locales = false
+Globalize.fallbacks = {:en => [:en, :de], :de => [:de, :en]}
 
 class Article < ActiveRecord::Base
-  translates :slug, :title
+  translates :slug, :title, fallbacks_for_empty_translations: true
   extend FriendlyId
   friendly_id :title, :use => [:slugged, :globalize]
 end


### PR DESCRIPTION
Hi,
in the first commit I've fixed the specs with the new Globalize gem.
In the second commit I've added the possibility to create a translated object with all translations in one single step. This is useful to integrate with ActiveAdmin (though it's not tested directly with that).
I've tested the new feature. Let me know if you need any explaination. Cheers!