### PR TITLE
Removed normalize_friendly_id from set_friendly_id

### DIFF
--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -85,7 +85,7 @@ current locale:
 
     def set_friendly_id(text, locale = nil)
       ::Globalize.with_locale(locale || ::Globalize.locale) do
-        set_slug normalize_friendly_id(text)
+        set_slug (text)
       end
     end
 


### PR DESCRIPTION
So we can pass the candidates and not only a string
