### PR TITLE
Fix ruby 2.7 deprecation message

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -70,7 +70,7 @@ method.
     # Configures the model instance to use the History add-on.
     def self.included(model_class)
       model_class.class_eval do
-        has_many :slugs, -> {order(Slug.arel_table[:id].desc)}, {
+        has_many :slugs, -> {order(Slug.arel_table[:id].desc)}, **{
           :as         => :sluggable,
           :dependent  => :destroy,
           :class_name => Slug.to_s


### PR DESCRIPTION
> Automatic conversion of keyword arguments and positional arguments is deprecated, and conversion will be removed in Ruby 3. 

https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/